### PR TITLE
MNT: Update to v1 recipe format and rattler-build

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.11.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.12.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.13.* *_cp313
-python_impl:
-- cpython
 target_platform:
 - linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.14.* *_cp314
-python_impl:
-- cpython
 target_platform:
 - linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.11.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.12.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.13.* *_cp313
-python_impl:
-- cpython
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.14.* *_cp314
-python_impl:
-- cpython
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.11.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.12.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.13.* *_cp313
-python_impl:
-- cpython
 target_platform:
 - linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -12,15 +16,14 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.14.* *_cp314
-python_impl:
-- cpython
 target_platform:
 - linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.11.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.12.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.13.* *_cp313
-python_impl:
-- cpython
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.14.* *_cp314
-python_impl:
-- cpython
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.11.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.12.* *_cpython
-python_impl:
-- cpython
 target_platform:
 - osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.13.* *_cp313
-python_impl:
-- cpython
 target_platform:
 - osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -16,15 +20,14 @@ cxx_compiler_version:
 - '19'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.14.* *_cp314
-python_impl:
-- cpython
 target_platform:
 - osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -58,7 +58,7 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
 fi
 
 
@@ -69,20 +69,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -79,33 +79,25 @@ source run_conda_forge_build_setup
 
 ( endgroup "Configuring conda" ) 2> /dev/null
 
-echo -e "\n\nMaking the build clobber file"
-make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build does not currently support debug mode"
 else
 
     if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
     fi
 
-    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
-        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+    rattler-build build --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="$flow_run_id" \
+        --extra-meta remote_url="$remote_url" \
+        --extra-meta sha="$sha"
 
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Home: https://lhapdf.hepforge.org/
 
 Package license: GPL-3.0-only
 
-Summary: LHAPDF is a general purpose C++ interpolator, used for evaluating PDFs from discretised data files. 
+Summary: LHAPDF is a general purpose C++ interpolator, used for evaluating PDFs from discretised data files.
 
 Development: https://gitlab.com/hepcedar/lhapdf
 
-Documentation: https://lhapdf.hepforge.org
+Documentation: https://lhapdf.hepforge.org/
 
 LHAPDF is a library implementing a standard to represent Parton
 Distribution Functions (PDFs) which is ubiquitous in the field of High Energy
@@ -26,7 +26,6 @@ Please make sure to cite the following paper if you use LHAPDF6
 "LHAPDF6: parton density access in the LHC precision era" Eur.Phys.J. C75
 (2015) 3, 132
 http://arxiv.org/abs/1412.7420
-
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,8 @@
 build_platform:
   linux_ppc64le: linux_64
 conda_build:
-  pkg_format: '2'
+  error_overlinking: true
+conda_build_tool: rattler-build
 conda_forge_output_validation: true
 conda_install_tool: pixi
 github:

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,239 +15,161 @@ requires-pixi = ">=0.59.0"
 [dependencies]
 conda-build = ">=24.1"
 conda-forge-ci-setup = "4.*"
-python = "3.12.*"
+rattler-build = "*"
 
 [tasks.inspect-all]
 cmd = "inspect_artifacts --all-packages"
-description = "List contents of all packages found in conda-build build directory."
+description = "List contents of all packages found in rattler-build build directory."
 [tasks.build]
-cmd = "conda-build build recipe"
+cmd = "rattler-build build --recipe recipe"
 description = "Build lhapdf-feedstock directly (without setup scripts), no particular variant specified"
-[tasks.debug]
-cmd = "conda-build debug recipe"
-description = "Debug lhapdf-feedstock directly (without setup scripts), no particular variant specified"
 [tasks."build-linux_64_python3.10.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_64_python3.10.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_python3.10.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_64_python3.10.____cpython directly (without setup scripts)"
-[tasks."debug-linux_64_python3.10.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_64_python3.10.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_64_python3.10.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_64_python3.10.____cpython"
 [tasks."build-linux_64_python3.11.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_64_python3.11.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_python3.11.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_64_python3.11.____cpython directly (without setup scripts)"
-[tasks."debug-linux_64_python3.11.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_64_python3.11.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_64_python3.11.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_64_python3.11.____cpython"
 [tasks."build-linux_64_python3.12.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_64_python3.12.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_python3.12.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_64_python3.12.____cpython directly (without setup scripts)"
-[tasks."debug-linux_64_python3.12.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_64_python3.12.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_64_python3.12.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_64_python3.12.____cpython"
 [tasks."build-linux_64_python3.13.____cp313"]
-cmd = "conda-build build recipe -m .ci_support/linux_64_python3.13.____cp313.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_python3.13.____cp313.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
 description = "Build lhapdf-feedstock with variant linux_64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."debug-linux_64_python3.13.____cp313"]
-cmd = "conda-build debug recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
-description = "Debug lhapdf-feedstock with variant linux_64_python3.13.____cp313 directly (without setup scripts)"
 [tasks."inspect-linux_64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_64_python3.13.____cp313"
 [tasks."build-linux_64_python3.14.____cp314"]
-cmd = "conda-build build recipe -m .ci_support/linux_64_python3.14.____cp314.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_64_python3.14.____cp314.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.14.____cp314.yaml"
 description = "Build lhapdf-feedstock with variant linux_64_python3.14.____cp314 directly (without setup scripts)"
-[tasks."debug-linux_64_python3.14.____cp314"]
-cmd = "conda-build debug recipe -m .ci_support/linux_64_python3.14.____cp314.yaml"
-description = "Debug lhapdf-feedstock with variant linux_64_python3.14.____cp314 directly (without setup scripts)"
 [tasks."inspect-linux_64_python3.14.____cp314"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.14.____cp314.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_64_python3.14.____cp314"
 [tasks."build-linux_aarch64_python3.10.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_python3.10.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_aarch64_python3.10.____cpython directly (without setup scripts)"
-[tasks."debug-linux_aarch64_python3.10.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_aarch64_python3.10.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_aarch64_python3.10.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_aarch64_python3.10.____cpython"
 [tasks."build-linux_aarch64_python3.11.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_python3.11.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_aarch64_python3.11.____cpython directly (without setup scripts)"
-[tasks."debug-linux_aarch64_python3.11.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_aarch64_python3.11.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_aarch64_python3.11.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_aarch64_python3.11.____cpython"
 [tasks."build-linux_aarch64_python3.12.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_python3.12.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_aarch64_python3.12.____cpython directly (without setup scripts)"
-[tasks."debug-linux_aarch64_python3.12.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_aarch64_python3.12.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_aarch64_python3.12.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_aarch64_python3.12.____cpython"
 [tasks."build-linux_aarch64_python3.13.____cp313"]
-cmd = "conda-build build recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_python3.13.____cp313.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
 description = "Build lhapdf-feedstock with variant linux_aarch64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."debug-linux_aarch64_python3.13.____cp313"]
-cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
-description = "Debug lhapdf-feedstock with variant linux_aarch64_python3.13.____cp313 directly (without setup scripts)"
 [tasks."inspect-linux_aarch64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_aarch64_python3.13.____cp313"
 [tasks."build-linux_aarch64_python3.14.____cp314"]
-cmd = "conda-build build recipe -m .ci_support/linux_aarch64_python3.14.____cp314.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_python3.14.____cp314.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.14.____cp314.yaml"
 description = "Build lhapdf-feedstock with variant linux_aarch64_python3.14.____cp314 directly (without setup scripts)"
-[tasks."debug-linux_aarch64_python3.14.____cp314"]
-cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_python3.14.____cp314.yaml"
-description = "Debug lhapdf-feedstock with variant linux_aarch64_python3.14.____cp314 directly (without setup scripts)"
 [tasks."inspect-linux_aarch64_python3.14.____cp314"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.14.____cp314.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_aarch64_python3.14.____cp314"
 [tasks."build-linux_ppc64le_python3.10.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_ppc64le_python3.10.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_ppc64le_python3.10.____cpython directly (without setup scripts)"
-[tasks."debug-linux_ppc64le_python3.10.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_ppc64le_python3.10.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_ppc64le_python3.10.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_ppc64le_python3.10.____cpython"
 [tasks."build-linux_ppc64le_python3.11.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_ppc64le_python3.11.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_ppc64le_python3.11.____cpython directly (without setup scripts)"
-[tasks."debug-linux_ppc64le_python3.11.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_ppc64le_python3.11.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_ppc64le_python3.11.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_ppc64le_python3.11.____cpython"
 [tasks."build-linux_ppc64le_python3.12.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_ppc64le_python3.12.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant linux_ppc64le_python3.12.____cpython directly (without setup scripts)"
-[tasks."debug-linux_ppc64le_python3.12.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant linux_ppc64le_python3.12.____cpython directly (without setup scripts)"
 [tasks."inspect-linux_ppc64le_python3.12.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_ppc64le_python3.12.____cpython"
 [tasks."build-linux_ppc64le_python3.13.____cp313"]
-cmd = "conda-build build recipe -m .ci_support/linux_ppc64le_python3.13.____cp313.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_ppc64le_python3.13.____cp313.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.13.____cp313.yaml"
 description = "Build lhapdf-feedstock with variant linux_ppc64le_python3.13.____cp313 directly (without setup scripts)"
-[tasks."debug-linux_ppc64le_python3.13.____cp313"]
-cmd = "conda-build debug recipe -m .ci_support/linux_ppc64le_python3.13.____cp313.yaml"
-description = "Debug lhapdf-feedstock with variant linux_ppc64le_python3.13.____cp313 directly (without setup scripts)"
 [tasks."inspect-linux_ppc64le_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.13.____cp313.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_ppc64le_python3.13.____cp313"
 [tasks."build-linux_ppc64le_python3.14.____cp314"]
-cmd = "conda-build build recipe -m .ci_support/linux_ppc64le_python3.14.____cp314.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_ppc64le_python3.14.____cp314.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.14.____cp314.yaml"
 description = "Build lhapdf-feedstock with variant linux_ppc64le_python3.14.____cp314 directly (without setup scripts)"
-[tasks."debug-linux_ppc64le_python3.14.____cp314"]
-cmd = "conda-build debug recipe -m .ci_support/linux_ppc64le_python3.14.____cp314.yaml"
-description = "Debug lhapdf-feedstock with variant linux_ppc64le_python3.14.____cp314 directly (without setup scripts)"
 [tasks."inspect-linux_ppc64le_python3.14.____cp314"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.14.____cp314.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant linux_ppc64le_python3.14.____cp314"
 [tasks."build-osx_64_python3.10.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/osx_64_python3.10.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_64_python3.10.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.10.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant osx_64_python3.10.____cpython directly (without setup scripts)"
-[tasks."debug-osx_64_python3.10.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/osx_64_python3.10.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant osx_64_python3.10.____cpython directly (without setup scripts)"
 [tasks."inspect-osx_64_python3.10.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.10.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_64_python3.10.____cpython"
 [tasks."build-osx_64_python3.11.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/osx_64_python3.11.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_64_python3.11.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant osx_64_python3.11.____cpython directly (without setup scripts)"
-[tasks."debug-osx_64_python3.11.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant osx_64_python3.11.____cpython directly (without setup scripts)"
 [tasks."inspect-osx_64_python3.11.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_64_python3.11.____cpython"
 [tasks."build-osx_64_python3.12.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/osx_64_python3.12.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_64_python3.12.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant osx_64_python3.12.____cpython directly (without setup scripts)"
-[tasks."debug-osx_64_python3.12.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant osx_64_python3.12.____cpython directly (without setup scripts)"
 [tasks."inspect-osx_64_python3.12.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_64_python3.12.____cpython"
 [tasks."build-osx_64_python3.13.____cp313"]
-cmd = "conda-build build recipe -m .ci_support/osx_64_python3.13.____cp313.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_64_python3.13.____cp313.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
 description = "Build lhapdf-feedstock with variant osx_64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."debug-osx_64_python3.13.____cp313"]
-cmd = "conda-build debug recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
-description = "Debug lhapdf-feedstock with variant osx_64_python3.13.____cp313 directly (without setup scripts)"
 [tasks."inspect-osx_64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_64_python3.13.____cp313"
 [tasks."build-osx_64_python3.14.____cp314"]
-cmd = "conda-build build recipe -m .ci_support/osx_64_python3.14.____cp314.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_64_python3.14.____cp314.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.14.____cp314.yaml"
 description = "Build lhapdf-feedstock with variant osx_64_python3.14.____cp314 directly (without setup scripts)"
-[tasks."debug-osx_64_python3.14.____cp314"]
-cmd = "conda-build debug recipe -m .ci_support/osx_64_python3.14.____cp314.yaml"
-description = "Debug lhapdf-feedstock with variant osx_64_python3.14.____cp314 directly (without setup scripts)"
 [tasks."inspect-osx_64_python3.14.____cp314"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.14.____cp314.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_64_python3.14.____cp314"
 [tasks."build-osx_arm64_python3.10.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.10.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant osx_arm64_python3.10.____cpython directly (without setup scripts)"
-[tasks."debug-osx_arm64_python3.10.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant osx_arm64_python3.10.____cpython directly (without setup scripts)"
 [tasks."inspect-osx_arm64_python3.10.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_arm64_python3.10.____cpython"
 [tasks."build-osx_arm64_python3.11.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.11.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant osx_arm64_python3.11.____cpython directly (without setup scripts)"
-[tasks."debug-osx_arm64_python3.11.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant osx_arm64_python3.11.____cpython directly (without setup scripts)"
 [tasks."inspect-osx_arm64_python3.11.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_arm64_python3.11.____cpython"
 [tasks."build-osx_arm64_python3.12.____cpython"]
-cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.12.____cpython.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
 description = "Build lhapdf-feedstock with variant osx_arm64_python3.12.____cpython directly (without setup scripts)"
-[tasks."debug-osx_arm64_python3.12.____cpython"]
-cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
-description = "Debug lhapdf-feedstock with variant osx_arm64_python3.12.____cpython directly (without setup scripts)"
 [tasks."inspect-osx_arm64_python3.12.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_arm64_python3.12.____cpython"
 [tasks."build-osx_arm64_python3.13.____cp313"]
-cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.13.____cp313.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
 description = "Build lhapdf-feedstock with variant osx_arm64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."debug-osx_arm64_python3.13.____cp313"]
-cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
-description = "Debug lhapdf-feedstock with variant osx_arm64_python3.13.____cp313 directly (without setup scripts)"
 [tasks."inspect-osx_arm64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_arm64_python3.13.____cp313"
 [tasks."build-osx_arm64_python3.14.____cp314"]
-cmd = "conda-build build recipe -m .ci_support/osx_arm64_python3.14.____cp314.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_arm64_python3.14.____cp314.yaml"
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.14.____cp314.yaml"
 description = "Build lhapdf-feedstock with variant osx_arm64_python3.14.____cp314 directly (without setup scripts)"
-[tasks."debug-osx_arm64_python3.14.____cp314"]
-cmd = "conda-build debug recipe -m .ci_support/osx_arm64_python3.14.____cp314.yaml"
-description = "Debug lhapdf-feedstock with variant osx_arm64_python3.14.____cp314 directly (without setup scripts)"
 [tasks."inspect-osx_arm64_python3.14.____cp314"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.14.____cp314.yaml"
 description = "List contents of lhapdf-feedstock packages built for variant osx_arm64_python3.14.____cp314"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -x
+set -ex
 
 if [[ $HOST == *apple* ]]; then
     # Bug for macOS as of lhapdf v6.1.1+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ autoreconf --install --force
 
 ./configure --help
 
-./configure --prefix=$PREFIX CXXFLAGS="${CXXFLAGS}"
+./configure --prefix=$PREFIX CXXFLAGS="${CXXFLAGS}" --disable-static --enable-shared
 
 make --jobs="${CPU_COUNT}"
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,34 +1,41 @@
-{% set name = "lhapdf" %}
-{% set version = "6.5.6" %}
+schema_version: 1
+
+context:
+  version: "6.5.6"
 
 package:
-  name: {{ name }}
-  version: {{ version }}
+  name: "lhapdf"
+  version: ${{ version }}
 
 source:
-  url: https://gitlab.com/hepcedar/lhapdf/-/archive/lhapdf-{{ version }}/lhapdf-lhapdf-{{ version }}.tar.gz
+  url: https://gitlab.com/hepcedar/lhapdf/-/archive/lhapdf-${{ version }}/lhapdf-lhapdf-${{ version }}.tar.gz
   sha256: 165143a5487d845d22e2d4dbe4ab4f51f09571756e80f71e3eacd7d412efb5d8
   patches:
     # Apply patch to wrappers/python/build.py.in to build bindings with Cython
     # https://gitlab.com/hepcedar/lhapdf/-/blob/c5b048f5794e483d85801d1ae39f42aaa46999dd/wrappers/python/build.py.in
-    - osx_patch.diff  # [osx]
+    - if: osx
+      then: osx_patch.diff
 
 build:
-  skip: true  # [win]
-  skip: true  # [python_impl == "pypy"]
-  number: 0
-  run_exports:
-    - {{ pin_subpackage("lhapdf", max_pin="x.x") }}
-  detect_binary_files_with_prefix: true
+  number: 1
+  skip:
+    - win
 
 requirements:
+  run_exports:
+    - ${{ pin_subpackage("lhapdf", upper_bound="x.x") }}
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython >=0.24  # [build_platform != target_platform]
-    - gnuconfig  # [unix]
-    - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
+    - ${{ stdlib("c") }}
+    - ${{ compiler("c") }}
+    - if: build_platform != host_platform
+      then:
+        - cross-python_${{ host_platform }}
+        - python
+        - cython
+    - if: unix
+      then: gnuconfig
+    - ${{ stdlib("c") }}
+    - ${{ compiler("cxx") }}
     - make
     - automake
     - autoconf
@@ -36,22 +43,37 @@ requirements:
     - wget
   host:
     - python
-    - cython >=0.24
+    - cython
   run:
     - python
 
-test:
-  requires:
-    - cxx-compiler
-    - numpy
-  source_files:
-    - examples
-  imports:
-    - lhapdf
+tests:
+  - package_contents:
+      bin:
+        - lhapdf
+        - lhapdf-config
+      lib:
+        - LHAPDF
+      include:
+        - LHAPDF/LHAPDF.h
+      files:
+        - share/LHAPDF/lhapdf.conf
+
+  - python:
+      imports:
+        - lhapdf
+
+  - files:
+      source:
+        - examples
+    requirements:
+      run:
+        - cxx-compiler
+        - numpy
+    script: run_test.sh
 
 about:
-  home: https://lhapdf.hepforge.org/
-  summary: 'LHAPDF is a general purpose C++ interpolator, used for evaluating PDFs from discretised data files. '
+  summary: LHAPDF is a general purpose C++ interpolator, used for evaluating PDFs from discretised data files.
   description: |
     LHAPDF is a library implementing a standard to represent Parton
     Distribution Functions (PDFs) which is ubiquitous in the field of High Energy
@@ -67,10 +89,10 @@ about:
     (2015) 3, 132
     http://arxiv.org/abs/1412.7420
   license: GPL-3.0-only
-  license_family: GPL
   license_file: COPYING
-  doc_url: https://lhapdf.hepforge.org
-  dev_url: https://gitlab.com/hepcedar/lhapdf
+  homepage: https://lhapdf.hepforge.org/
+  repository: https://gitlab.com/hepcedar/lhapdf
+  documentation: https://lhapdf.hepforge.org
 
 extra:
   recipe-maintainers:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,57 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-#
-echo -e "\n# Check installed directory structure"
-echo "# test -d ${PREFIX}/bin"
-test -d "${PREFIX}/bin"
-echo "# test -d ${PREFIX}/include"
-test -d "${PREFIX}/include"
-echo "# test -d ${PREFIX}/include/LHAPDF"
-test -d "${PREFIX}/include/LHAPDF"
-echo "# test -d ${PREFIX}/lib"
-test -d "${PREFIX}/lib"
-echo "# test -d ${PREFIX}/share"
-test -d "${PREFIX}/share"
-echo "# test -d ${PREFIX}/share/LHAPDF"
-test -d "${PREFIX}/share/LHAPDF"
+set -ex
 
-echo -e "\n# Check installed files"
-echo "# test -f ${PREFIX}/bin/lhapdf"
-test -f "${PREFIX}/bin/lhapdf"
-echo "# test -f ${PREFIX}/bin/lhapdf-config"
-test -f "${PREFIX}/bin/lhapdf-config"
-echo "# test -f ${PREFIX}/include/LHAPDF/LHAPDF.h"
-test -f "${PREFIX}/include/LHAPDF/LHAPDF.h"
-if [[ "${target_platform}" == linux-* ]]; then
-    echo "# test -f ${PREFIX}/lib/libLHAPDF.so"
-    test -f "${PREFIX}/lib/libLHAPDF.so"
-else
-    # macOS
-    echo "# test -f ${PREFIX}/lib/libLHAPDF.dylib"
-    test -f "${PREFIX}/lib/libLHAPDF.dylib"
-fi
-echo "# test -f ${PREFIX}/share/LHAPDF/lhapdf.conf"
-test -f "${PREFIX}/share/LHAPDF/lhapdf.conf"
-
-#
-echo -e "\n# Check lhapdf-config CLI API and flags return expected values"
-echo -e "# lhapdf-config --help\n"
-lhapdf-config --help
-
-echo -e "# lhapdf-config --version\n"
 lhapdf-config --version
+
+echo -e "\n# Check lhapdf-config CLI API and flags return expected values"
+lhapdf-config --help
 
 echo -e "\n# lhapdf-config --cxxflags: $(lhapdf-config --cxxflags)"
 
 echo -e "\n# lhapdf-config --ldflags: $(lhapdf-config --ldflags)"
 
 echo -e "\n# Check lhapdf CLI API"
-echo -e "# lhapdf --help\n"
 lhapdf --help
 
 #
 cd examples/
-echo -e "\n# Test example analyticpdf"
 "$CXX" analyticpdf.cc \
     -o analyticpdf \
     $(lhapdf-config --cxxflags --libs) \
@@ -59,11 +23,10 @@ echo -e "\n# Test example analyticpdf"
 ./analyticpdf
 
 # needed for: compatibility, reweight, pythonexample.py
-echo -e "\n# lhapdf install CT10nlo\n"
 # avoid lots of output to stdout from download of the file
+lhapdf update
 lhapdf install CT10nlo &> /dev/null
 
-echo -e "\n# Test example compatibility"
 "$CXX" compatibility.cc \
     -o compatibility \
     $(lhapdf-config --cxxflags --libs) \
@@ -71,10 +34,8 @@ echo -e "\n# Test example compatibility"
 ./compatibility
 
 # needed for hessian2replicas
-echo -e "\n# lhapdf install MSTW2008nnlo68cl\n"
 lhapdf install MSTW2008nnlo68cl &> /dev/null
 
-echo -e "\n# Test example hessian2replicas"
 "$CXX" hessian2replicas.cc \
     -o hessian2replicas \
     $(lhapdf-config --cxxflags --libs) \
@@ -82,15 +43,12 @@ echo -e "\n# Test example hessian2replicas"
 ./hessian2replicas MSTW2008nnlo68cl 1234 10
 
 # needed for reweight
-echo -e "\n# lhapdf install MSTW2008lo68cl\n"
 lhapdf install MSTW2008lo68cl &> /dev/null
 
-echo -e "\n# Test example reweight"
 "$CXX" reweight.cc \
     -o reweight \
     $(lhapdf-config --cxxflags --libs) \
     -Wl,-rpath,"$(lhapdf-config --libdir)"
 ./reweight CT10nlo/0 MSTW2008lo68cl/0
 
-echo -e "\n# Test example pythonexample.py"
 python pythonexample.py


### PR DESCRIPTION
* Update to v1 recipe format.
   - c.f. https://conda-forge.org/blog/2025/02/27/conda-forge-v1-recipe-support/
* Add rattler-build as tooling.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
