### PR TITLE
MNT: Remove duplicate stdlib c 

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-aarch64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-aarch64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -24,6 +20,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - osx-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - osx-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -2,10 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -28,6 +24,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "lhapdf-feedstock"
-version = "3.59.0"  # conda-smithy version used to generate this file
+version = "3.59.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/lhapdf-feedstock"
 authors = ["@conda-forge/lhapdf"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ source:
       then: osx_patch.diff
 
 build:
-  number: 1
+  number: 2
   skip:
     - win
 
@@ -26,7 +26,7 @@ requirements:
     - ${{ pin_subpackage("lhapdf", upper_bound="x.x") }}
   build:
     - ${{ stdlib("c") }}
-    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
     - if: build_platform != host_platform
       then:
         - cross-python_${{ host_platform }}
@@ -34,8 +34,6 @@ requirements:
         - cython
     - if: unix
       then: gnuconfig
-    - ${{ stdlib("c") }}
-    - ${{ compiler("cxx") }}
     - make
     - automake
     - autoconf


### PR DESCRIPTION
* Remove duplicated `${{ stdlib("c") }}`.
* Remove `${{ compiler("c") }}` as `${{ compiler("cxx") }}` requires it.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
